### PR TITLE
Take subject from sendinblue / brevo template

### DIFF
--- a/Transport/SendinblueApiTransport.php
+++ b/Transport/SendinblueApiTransport.php
@@ -88,8 +88,10 @@ final class SendinblueApiTransport extends AbstractApiTransport
         $payload = [
             'sender' => $this->stringifyAddress($envelope->getSender()),
             'to' => $this->stringifyAddresses($this->getRecipients($email, $envelope)),
-            'subject' => $email->getSubject(),
         ];
+        if ($subject = $email->getSubject() && !empty($subject)) {
+            $payload['subject'] = $subject;
+        }
         if ($attachements = $this->prepareAttachments($email)) {
             $payload['attachment'] = $attachements;
         }


### PR DESCRIPTION
At the moment the subject is always submitted to the brevo api.  

The docs say that it does not need to be passed if you are using a template:  
https://developers.brevo.com/reference/sendtransacemail

This change adds the ability to set an empty subject. This way the default subject from the brevo template gets used.