### PR TITLE
Replace old SendInBlue URIs with Brevo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 phpunit.xml
+.idea/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This example allow you to set :
     * sender.ip
     * X-Mailin-Custom
 
-For more informations, you can refer to [Sendinblue API documentation](https://developers.sendinblue.com/reference#sendtransacemail).
+For more informations, you can refer to [Sendinblue API documentation](https://developers.brevo.com/reference#sendtransacemail).
 
 Resources
 ---------

--- a/Tests/Transport/SendinblueApiTransportTest.php
+++ b/Tests/Transport/SendinblueApiTransportTest.php
@@ -38,7 +38,7 @@ class SendinblueApiTransportTest extends TestCase
     {
         yield [
             new SendinblueApiTransport('ACCESS_KEY'),
-            'sendinblue+api://api.sendinblue.com',
+            'sendinblue+api://api.brevo.com',
         ];
 
         yield [
@@ -89,7 +89,7 @@ class SendinblueApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.sendinblue.com:8984/v3/smtp/email', $url);
+            $this->assertSame('https://api.brevo.com:8984/v3/smtp/email', $url);
             $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
 
             return new MockResponse(json_encode(['message' => 'i\'m a teapot']), [
@@ -119,7 +119,7 @@ class SendinblueApiTransportTest extends TestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
-            $this->assertSame('https://api.sendinblue.com:8984/v3/smtp/email', $url);
+            $this->assertSame('https://api.brevo.com:8984/v3/smtp/email', $url);
             $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
 
             return new MockResponse(json_encode(['messageId' => 'foobar']), [

--- a/Transport/SendinblueApiTransport.php
+++ b/Transport/SendinblueApiTransport.php
@@ -180,6 +180,6 @@ final class SendinblueApiTransport extends AbstractApiTransport
 
     private function getEndpoint(): ?string
     {
-        return ($this->host ?: 'api.sendinblue.com').($this->port ? ':'.$this->port : '');
+        return ($this->host ?: 'api.brevo.com').($this->port ? ':'.$this->port : '');
     }
 }

--- a/Transport/SendinblueSmtpTransport.php
+++ b/Transport/SendinblueSmtpTransport.php
@@ -22,7 +22,7 @@ final class SendinblueSmtpTransport extends EsmtpTransport
 {
     public function __construct(string $username, #[\SensitiveParameter] string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp-relay.sendinblue.com', 465, true, $dispatcher, $logger);
+        parent::__construct('smtp-relay.brevo.com', 465, true, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);


### PR DESCRIPTION
Updates to conform with the update outlined here https://developers.brevo.com/docs/changes-in-smtp-relay-address?utm_source=brevo&utm_medium=email&utm_campaign=EN-product-update-SMTP%20Relay%20-%2007%2023&utm_term=07+2023