### PR TITLE
[FIX] Use idn encoded address otherwise brevo throws an error

### DIFF
--- a/Transport/SendinblueApiTransport.php
+++ b/Transport/SendinblueApiTransport.php
@@ -169,7 +169,7 @@ final class SendinblueApiTransport extends AbstractApiTransport
 
     private function stringifyAddress(Address $address): array
     {
-        $stringifiedAddress = ['email' => $address->getAddress()];
+        $stringifiedAddress = ['email' => $address->getEncodedAddress()];
 
         if ($address->getName()) {
             $stringifiedAddress['name'] = $address->getName();


### PR DESCRIPTION
We have to use the encoded email address in case of special character domains like 'kältetechnik-xyz.de' otherwise brevo fails with 400 error.